### PR TITLE
Allow transactions to expire based on the wall clock time

### DIFF
--- a/libraries/mempool/include/koinos/mempool/mempool.hpp
+++ b/libraries/mempool/include/koinos/mempool/mempool.hpp
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <chrono>
 #include <memory>
 #include <vector>
 
@@ -39,7 +40,7 @@ public:
 
    uint64_t add_pending_transaction(
       const protocol::transaction& transaction,
-      block_height_type height,
+      std::chrono::system_clock::time_point time,
       uint64_t max_payer_rc,
       uint64_t disk_storaged_used,
       uint64_t network_bandwidth_used,
@@ -48,7 +49,7 @@ public:
    bool has_pending_transaction( const transaction_id_type& id )const;
    std::vector< rpc::mempool::pending_transaction > get_pending_transactions( std::size_t limit = MAX_PENDING_TRANSACTION_REQUEST );
    void remove_pending_transactions( const std::vector< transaction_id_type >& ids );
-   void prune( block_height_type h );
+   void prune( std::chrono::seconds expiration, std::chrono::system_clock::time_point now = std::chrono::system_clock::now() );
    std::size_t payer_entries_size() const;
    std::size_t pending_transaction_count() const;
 };

--- a/tests/tests/mempool_test.cpp
+++ b/tests/tests/mempool_test.cpp
@@ -11,6 +11,7 @@
 #include <memory>
 
 using namespace koinos;
+using namespace std::chrono_literals;
 
 struct mempool_fixture
 {
@@ -61,11 +62,11 @@ BOOST_AUTO_TEST_CASE( mempool_basic_test )
 
    BOOST_TEST_MESSAGE( "adding pending transaction" );
    auto trx_resource_limit = t1.header().rc_limit();
-   auto rc_used = mempool.add_pending_transaction( t1, 1, max_payer_resources, 1, 2, 3 );
+   auto rc_used = mempool.add_pending_transaction( t1, std::chrono::system_clock::now(), max_payer_resources, 1, 2, 3 );
    BOOST_CHECK_EQUAL( t1.header().rc_limit(), rc_used );
 
    BOOST_TEST_MESSAGE( "adding duplicate pending transaction" );
-   BOOST_REQUIRE_THROW( mempool.add_pending_transaction( t1, 2, max_payer_resources, 1, 2, 3 ), mempool::pending_transaction_insertion_failure );
+   BOOST_REQUIRE_THROW( mempool.add_pending_transaction( t1, std::chrono::system_clock::now(), max_payer_resources, 1, 2, 3 ), mempool::pending_transaction_insertion_failure );
 
    BOOST_TEST_MESSAGE( "checking payer was not charged for failed pending transaction" );
    BOOST_REQUIRE( mempool.check_pending_account_resources( payer, max_payer_resources, max_payer_resources - trx_resource_limit ) );
@@ -97,7 +98,7 @@ BOOST_AUTO_TEST_CASE( mempool_basic_test )
    BOOST_TEST_MESSAGE( "adding pending transaction that exceeds accout resources" );
    max_payer_resources = 1000000000000;
    trx_resource_limit = t2.header().rc_limit();
-   BOOST_REQUIRE_THROW( mempool.add_pending_transaction( t2, 3, max_payer_resources, 1, 1, 1 ), mempool::pending_transaction_exceeds_resources );
+   BOOST_REQUIRE_THROW( mempool.add_pending_transaction( t2, std::chrono::system_clock::now(), max_payer_resources, 1, 1, 1 ), mempool::pending_transaction_exceeds_resources );
 
    BOOST_TEST_MESSAGE( "removing pending transactions" );
    mempool.remove_pending_transactions( std::vector< mempool::transaction_id_type >{ t1.id() } );
@@ -134,7 +135,7 @@ BOOST_AUTO_TEST_CASE( pending_transaction_pagination )
 
       rc_used += trx.header().rc_limit();
 
-      auto rc = mempool.add_pending_transaction( trx, i, max_payer_resources, 1, 1, 1 );
+      auto rc = mempool.add_pending_transaction( trx, std::chrono::system_clock::now(), max_payer_resources, 1, 1, 1 );
       BOOST_CHECK_EQUAL( rc, rc_used );
    }
 
@@ -162,6 +163,7 @@ BOOST_AUTO_TEST_CASE( pending_transaction_pruning )
    uint64_t trx_resource_limit;
    chain::value_type nonce_value;
 
+   auto now = std::chrono::system_clock::now();
 
    payer = _key1.get_public_key().to_address_bytes();
    max_payer_resources = 1000000000000;
@@ -171,7 +173,7 @@ BOOST_AUTO_TEST_CASE( pending_transaction_pruning )
    trx.mutable_header()->set_nonce( util::converter::as< std::string >( nonce_value ) );
    trx.set_id( sign( _key1, trx ) );
 
-   mempool.add_pending_transaction( trx, 1, max_payer_resources, 1, 1, 1 );
+   mempool.add_pending_transaction( trx, now, max_payer_resources, 1, 1, 1 );
 
    payer = _key2.get_public_key().to_address_bytes();
    max_payer_resources = 1000000000000;
@@ -181,7 +183,7 @@ BOOST_AUTO_TEST_CASE( pending_transaction_pruning )
    trx.mutable_header()->set_nonce( util::converter::as< std::string >( nonce_value ) );
    trx.set_id( sign( _key2, trx ) );
 
-   mempool.add_pending_transaction( trx, 1, max_payer_resources, 1, 1, 1 );
+   mempool.add_pending_transaction( trx, now, max_payer_resources, 1, 1, 1 );
 
    payer = _key1.get_public_key().to_address_bytes();
    max_payer_resources = 1000000000000;
@@ -191,7 +193,7 @@ BOOST_AUTO_TEST_CASE( pending_transaction_pruning )
    trx.mutable_header()->set_nonce( util::converter::as< std::string >( nonce_value ) );
    trx.set_id( sign( _key1, trx ) );
 
-   mempool.add_pending_transaction( trx, 2, max_payer_resources, 1, 1, 1 );
+   mempool.add_pending_transaction( trx, now + 1s, max_payer_resources, 1, 1, 1 );
 
    payer = _key3.get_public_key().to_address_bytes();
    max_payer_resources = 1000000000000;
@@ -201,7 +203,7 @@ BOOST_AUTO_TEST_CASE( pending_transaction_pruning )
    trx.mutable_header()->set_nonce( util::converter::as< std::string >( nonce_value ) );
    trx.set_id( sign( _key3, trx ) );
 
-   mempool.add_pending_transaction( trx, 2, max_payer_resources, 1, 1, 1 );
+   mempool.add_pending_transaction( trx, now + 1s, max_payer_resources, 1, 1, 1 );
 
    auto pending_trxs = mempool.get_pending_transactions();
    BOOST_CHECK_EQUAL( mempool.payer_entries_size(), 3 );
@@ -211,7 +213,7 @@ BOOST_AUTO_TEST_CASE( pending_transaction_pruning )
       BOOST_REQUIRE_EQUAL( pending_trxs[i].transaction().header().rc_limit(), i + 1 );
    }
 
-   mempool.prune( 1 );
+   mempool.prune( 1s, now + 1s );
    pending_trxs = mempool.get_pending_transactions();
    BOOST_CHECK_EQUAL( mempool.payer_entries_size(), 2 );
    BOOST_REQUIRE_EQUAL( pending_trxs.size(), 2 );
@@ -220,7 +222,7 @@ BOOST_AUTO_TEST_CASE( pending_transaction_pruning )
       BOOST_REQUIRE_EQUAL( pending_trxs[i].transaction().header().rc_limit(), i + 3 );
    }
 
-   mempool.prune( 2 );
+   mempool.prune( 1s, now + 2s );
    pending_trxs = mempool.get_pending_transactions();
    BOOST_CHECK_EQUAL( mempool.payer_entries_size(), 0 );
    BOOST_REQUIRE_EQUAL( pending_trxs.size(), 0 );
@@ -245,7 +247,7 @@ BOOST_AUTO_TEST_CASE( pending_transaction_dynamic_max_resources )
    trx.mutable_header()->set_nonce( util::converter::as< std::string >( nonce_value ) );
    trx.set_id( sign( _key1, trx ) );
 
-   mempool.add_pending_transaction( trx, 1, max_payer_resources, 1, 1, 1 );
+   mempool.add_pending_transaction( trx, std::chrono::system_clock::now(), max_payer_resources, 1, 1, 1 );
 
    for ( unsigned int i = 2; i < 10; i++ )
    {
@@ -257,7 +259,7 @@ BOOST_AUTO_TEST_CASE( pending_transaction_dynamic_max_resources )
       trx.mutable_header()->set_nonce( util::converter::as< std::string >( nonce_value ) );
       trx.set_id( sign( _key1, trx ) );
 
-      mempool.add_pending_transaction( trx, i, max_payer_resources, 1, 1, 1 );
+      mempool.add_pending_transaction( trx, std::chrono::system_clock::now(), max_payer_resources, 1, 1, 1 );
    }
 
    max_payer_resources = max_payer_resources + 99;
@@ -269,7 +271,7 @@ BOOST_AUTO_TEST_CASE( pending_transaction_dynamic_max_resources )
    trx.set_id( sign( _key1, trx ) );
 
    BOOST_REQUIRE_THROW(
-      mempool.add_pending_transaction( trx, 10, max_payer_resources, 1, 1, 1 ),
+      mempool.add_pending_transaction( trx, std::chrono::system_clock::now(), max_payer_resources, 1, 1, 1 ),
       mempool::pending_transaction_exceeds_resources
    );
 
@@ -284,7 +286,7 @@ BOOST_AUTO_TEST_CASE( pending_transaction_dynamic_max_resources )
    trx.mutable_header()->set_nonce( util::converter::as< std::string >( nonce_value ) );
    trx.set_id( sign( _key2, trx ) );
 
-   mempool.add_pending_transaction( trx, 1, max_payer_resources, 1, 1, 1 );
+   mempool.add_pending_transaction( trx, std::chrono::system_clock::now(), max_payer_resources, 1, 1, 1 );
 
    max_payer_resources = 999999999990;
    trx_resource_limit = 10;
@@ -295,7 +297,7 @@ BOOST_AUTO_TEST_CASE( pending_transaction_dynamic_max_resources )
    trx.mutable_header()->set_nonce( util::converter::as< std::string >( nonce_value ) );
    trx.set_id( sign( _key2, trx ) );
 
-   mempool.add_pending_transaction( trx, 2, max_payer_resources, 1, 1, 1 );
+   mempool.add_pending_transaction( trx, std::chrono::system_clock::now(), max_payer_resources, 1, 1, 1 );
 
    trx_resource_limit = 1;
    nonce_value.set_uint64_value( 12 );
@@ -305,7 +307,7 @@ BOOST_AUTO_TEST_CASE( pending_transaction_dynamic_max_resources )
    trx.set_id( sign( _key2, trx ) );
 
    BOOST_REQUIRE_THROW(
-      mempool.add_pending_transaction( trx, 3, max_payer_resources, 1, 1, 1 ),
+      mempool.add_pending_transaction( trx, std::chrono::system_clock::now(), max_payer_resources, 1, 1, 1 ),
       mempool::pending_transaction_exceeds_resources
    );
 }
@@ -318,6 +320,8 @@ BOOST_AUTO_TEST_CASE( mempool_nonce_test )
    uint64_t max_payer_resources = 1000000000000ull;
    chain::value_type nonce_value;
 
+   auto now = std::chrono::system_clock::now();
+
    BOOST_TEST_MESSAGE( "adding pending transactions" );
 
    protocol::transaction t1;
@@ -326,7 +330,7 @@ BOOST_AUTO_TEST_CASE( mempool_nonce_test )
    t1.mutable_header()->set_payer( payer );
    t1.mutable_header()->set_nonce( util::converter::as< std::string >( nonce_value ) );
    t1.set_id( sign( _key1, t1 ) );
-   mempool.add_pending_transaction( t1, 1, max_payer_resources, 1, 2, 3 );
+   mempool.add_pending_transaction( t1, now, max_payer_resources, 1, 2, 3 );
 
    protocol::transaction t2;
    payer = _key2.get_public_key().to_address_bytes();
@@ -335,7 +339,7 @@ BOOST_AUTO_TEST_CASE( mempool_nonce_test )
    t2.mutable_header()->set_payer( payer );
    t2.mutable_header()->set_nonce( util::converter::as< std::string >( nonce_value ) );
    t2.set_id( sign( _key2, t2 ) );
-   mempool.add_pending_transaction( t2, 2, max_payer_resources, 1, 2, 3 );
+   mempool.add_pending_transaction( t2, now + 1s, max_payer_resources, 1, 2, 3 );
 
    protocol::transaction t3;
    nonce_value.set_uint64_value( 3 );
@@ -344,7 +348,7 @@ BOOST_AUTO_TEST_CASE( mempool_nonce_test )
    t3.mutable_header()->set_payer( payer );
    t3.mutable_header()->set_nonce( util::converter::as< std::string >( nonce_value ) );
    t3.set_id( sign( _key1, t3 ) );
-   mempool.add_pending_transaction( t3, 3, max_payer_resources, 1, 2, 3 );
+   mempool.add_pending_transaction( t3, now + 2s, max_payer_resources, 1, 2, 3 );
 
    protocol::transaction t4;
    nonce_value.set_uint64_value( 1 );
@@ -352,7 +356,7 @@ BOOST_AUTO_TEST_CASE( mempool_nonce_test )
    t4.mutable_header()->set_payer( payer );
    t4.mutable_header()->set_nonce( util::converter::as< std::string >( nonce_value ) );
    t4.set_id( sign( _key1, t4 ) );
-   mempool.add_pending_transaction( t4, 4, max_payer_resources, 1, 2, 3 );
+   mempool.add_pending_transaction( t4, now + 3s, max_payer_resources, 1, 2, 3 );
 
    protocol::transaction t5;
    payer = _key2.get_public_key().to_address_bytes();
@@ -361,7 +365,7 @@ BOOST_AUTO_TEST_CASE( mempool_nonce_test )
    t5.mutable_header()->set_payer( payer );
    t5.mutable_header()->set_nonce( util::converter::as< std::string >( nonce_value ) );
    t5.set_id( sign( _key2, t5 ) );
-   mempool.add_pending_transaction( t5, 5, max_payer_resources, 1, 2, 3 );
+   mempool.add_pending_transaction( t5, now + 4s, max_payer_resources, 1, 2, 3 );
 
    BOOST_TEST_MESSAGE( "checking pending transaction list" );
    // Order should be t4, t1, t5, t2, t3
@@ -370,29 +374,29 @@ BOOST_AUTO_TEST_CASE( mempool_nonce_test )
    BOOST_TEST_MESSAGE( "checking pending transactions size" );
    BOOST_REQUIRE_EQUAL( pending_txs.size(), 5 );
    BOOST_TEST_MESSAGE( "checking pending transaction ids" );
-   BOOST_REQUIRE( pending_txs[0].transaction().id() == t4.id() ); // Height 1
-   BOOST_REQUIRE( pending_txs[1].transaction().id() == t1.id() ); // Height 1
-   BOOST_REQUIRE( pending_txs[2].transaction().id() == t5.id() ); // Height 2
-   BOOST_REQUIRE( pending_txs[3].transaction().id() == t2.id() ); // Height 2
-   BOOST_REQUIRE( pending_txs[4].transaction().id() == t3.id() ); // Height 5
+   BOOST_REQUIRE( pending_txs[0].transaction().id() == t4.id() );
+   BOOST_REQUIRE( pending_txs[1].transaction().id() == t1.id() );
+   BOOST_REQUIRE( pending_txs[2].transaction().id() == t5.id() );
+   BOOST_REQUIRE( pending_txs[3].transaction().id() == t2.id() );
+   BOOST_REQUIRE( pending_txs[4].transaction().id() == t3.id() );
 
-   mempool.prune( 1 ); // Removes t4 and t1
+   mempool.prune( 1s, now + 2s ); // Removes t1 and t2
 
    pending_txs = mempool.get_pending_transactions();
    BOOST_TEST_MESSAGE( "checking pending transactions size" );
    BOOST_REQUIRE_EQUAL( pending_txs.size(), 3 );
    BOOST_TEST_MESSAGE( "checking pending transaction ids" );
-   BOOST_REQUIRE( pending_txs[0].transaction().id() == t5.id() ); // Height 2
-   BOOST_REQUIRE( pending_txs[1].transaction().id() == t2.id() ); // Height 2
-   BOOST_REQUIRE( pending_txs[2].transaction().id() == t3.id() ); // Height 5
+   BOOST_REQUIRE( pending_txs[0].transaction().id() == t4.id() );
+   BOOST_REQUIRE( pending_txs[1].transaction().id() == t5.id() );
+   BOOST_REQUIRE( pending_txs[2].transaction().id() == t3.id() );
 
-   mempool.prune( 2 ); // Removed t5 and t2
+   mempool.prune( 1s, now + 4s ); // Removed t3 and t4
 
    pending_txs = mempool.get_pending_transactions();
    BOOST_TEST_MESSAGE( "checking pending transactions size" );
    BOOST_REQUIRE_EQUAL( pending_txs.size(), 1 );
    BOOST_TEST_MESSAGE( "checking pending transaction ids" );
-   BOOST_REQUIRE( pending_txs[0].transaction().id() == t3.id() ); // Height 5
+   BOOST_REQUIRE( pending_txs[0].transaction().id() == t5.id() );
 }
 
 BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
Resolves #64.

## Brief description
Allow transactions to expire based on the wall clock time. Adds the configuration option `transaction-expiration` which takes the number of seconds a transaction should expire after.

## Checklist

- [x] I have built this pull request locally
- [x] I have ran the unit tests locally
- [x] I have manually tested this pull request
- [x] I have reviewed my pull request
- [x] I have added any relevant tests

## Demonstration
```console
❯ ./programs/koinos_mempool/Debug/koinos_mempool
2022-10-04 17:19:51.075666 (mempool.Koinos) [main.cpp:124] <info>: Starting mempool...
2022-10-04 17:19:51.076853 (mempool.Koinos) [main.cpp:125] <info>: Number of jobs: 8
2022-10-04 17:19:51.076947 (mempool.Koinos) [main.cpp:126] <info>: Transaction expiration: 120s
2022-10-04 17:19:51.078407 (mempool.Koinos) [main.cpp:312] <info>: Connecting AMQP client...
2022-10-04 17:19:51.082048 (mempool.Koinos) [retryer.cpp:106] <warning>: Failure during client connection to AMQP, retrying in 1000ms
2022-10-04 17:19:52.082746 (mempool.Koinos) [retryer.cpp:73] <warning>: Failure during client connection to AMQP, retrying in 2000ms
2022-10-04 17:19:54.083530 (mempool.Koinos) [retryer.cpp:73] <warning>: Failure during client connection to AMQP, retrying in 4000ms
^C2022-10-04 17:19:54.456569 (mempool.Koinos) [main.cpp:137] <info>: Caught signal, shutting down...
2022-10-04 17:19:54.458776 (mempool.Koinos) [main.cpp:358] <info>: Shut down gracefully
```
