### PR TITLE
Squelch pending transactions message log when there are none

### DIFF
--- a/libraries/mempool/include/koinos/mempool/mempool.hpp
+++ b/libraries/mempool/include/koinos/mempool/mempool.hpp
@@ -2,6 +2,7 @@
 
 #include <chrono>
 #include <memory>
+#include <utility>
 #include <vector>
 
 #include <koinos/crypto/multihash.hpp>
@@ -48,7 +49,7 @@ public:
 
    bool has_pending_transaction( const transaction_id_type& id )const;
    std::vector< rpc::mempool::pending_transaction > get_pending_transactions( std::size_t limit = MAX_PENDING_TRANSACTION_REQUEST );
-   void remove_pending_transactions( const std::vector< transaction_id_type >& ids );
+   std::pair< uint64_t, uint64_t > remove_pending_transactions( const std::vector< transaction_id_type >& ids );
    void prune( std::chrono::seconds expiration, std::chrono::system_clock::time_point now = std::chrono::system_clock::now() );
    std::size_t payer_entries_size() const;
    std::size_t pending_transaction_count() const;

--- a/libraries/mempool/include/koinos/mempool/mempool.hpp
+++ b/libraries/mempool/include/koinos/mempool/mempool.hpp
@@ -50,7 +50,7 @@ public:
    bool has_pending_transaction( const transaction_id_type& id )const;
    std::vector< rpc::mempool::pending_transaction > get_pending_transactions( std::size_t limit = MAX_PENDING_TRANSACTION_REQUEST );
    std::pair< uint64_t, uint64_t > remove_pending_transactions( const std::vector< transaction_id_type >& ids );
-   void prune( std::chrono::seconds expiration, std::chrono::system_clock::time_point now = std::chrono::system_clock::now() );
+   uint64_t prune( std::chrono::seconds expiration, std::chrono::system_clock::time_point now = std::chrono::system_clock::now() );
    std::size_t payer_entries_size() const;
    std::size_t pending_transaction_count() const;
 };

--- a/libraries/mempool/mempool.cpp
+++ b/libraries/mempool/mempool.cpp
@@ -149,7 +149,7 @@ public:
       uint64_t network_bandwidth_used,
       uint64_t compute_bandwidth_used );
    std::pair< uint64_t, uint64_t > remove_pending_transactions( const std::vector< transaction_id_type >& ids );
-   void prune( std::chrono::seconds expiration, std::chrono::system_clock::time_point now );
+   uint64_t prune( std::chrono::seconds expiration, std::chrono::system_clock::time_point now );
    std::size_t payer_entries_size() const;
    void cleanup_account_resources( const pending_transaction_object& pending_trx );
    std::size_t pending_transaction_count() const;
@@ -377,7 +377,7 @@ std::pair< uint64_t, uint64_t > mempool_impl::remove_pending_transactions( const
    return std::make_pair( count, _pending_transactions.size() );
 }
 
-void mempool_impl::prune( std::chrono::seconds expiration, std::chrono::system_clock::time_point now )
+uint64_t mempool_impl::prune( std::chrono::seconds expiration, std::chrono::system_clock::time_point now )
 {
    std::lock_guard< std::mutex > account_guard( _account_resources_mutex );
    std::lock_guard< std::mutex > trx_guard( _pending_transaction_mutex );
@@ -396,8 +396,7 @@ void mempool_impl::prune( std::chrono::seconds expiration, std::chrono::system_c
       count++;
    }
 
-   if ( count )
-      LOG(info) << "Pruned " << count << " transaction(s) from mempool";
+   return count;
 }
 
 std::size_t mempool_impl::payer_entries_size() const
@@ -470,9 +469,9 @@ std::pair< uint64_t, uint64_t > mempool::remove_pending_transactions( const std:
    return _my->remove_pending_transactions( ids );
 }
 
-void mempool::prune( std::chrono::seconds expiration, std::chrono::system_clock::time_point now )
+uint64_t mempool::prune( std::chrono::seconds expiration, std::chrono::system_clock::time_point now )
 {
-   _my->prune( expiration, now );
+   return _my->prune( expiration, now );
 }
 
 std::size_t mempool::payer_entries_size() const

--- a/libraries/mempool/mempool.cpp
+++ b/libraries/mempool/mempool.cpp
@@ -148,7 +148,7 @@ public:
       uint64_t disk_storaged_used,
       uint64_t network_bandwidth_used,
       uint64_t compute_bandwidth_used );
-   void remove_pending_transactions( const std::vector< transaction_id_type >& ids );
+   std::pair< uint64_t, uint64_t > remove_pending_transactions( const std::vector< transaction_id_type >& ids );
    void prune( std::chrono::seconds expiration, std::chrono::system_clock::time_point now );
    std::size_t payer_entries_size() const;
    void cleanup_account_resources( const pending_transaction_object& pending_trx );
@@ -353,7 +353,7 @@ uint64_t mempool_impl::add_pending_transaction(
    return rc_used;
 }
 
-void mempool_impl::remove_pending_transactions( const std::vector< transaction_id_type >& ids )
+std::pair< uint64_t, uint64_t > mempool_impl::remove_pending_transactions( const std::vector< transaction_id_type >& ids )
 {
    std::lock_guard< std::mutex > account_guard( _account_resources_mutex );
    std::lock_guard< std::mutex > trx_guard( _pending_transaction_mutex );
@@ -374,8 +374,7 @@ void mempool_impl::remove_pending_transactions( const std::vector< transaction_i
       }
    }
 
-   if ( count )
-      LOG(info) << "Removed " << count << " included transaction(s) from mempool";
+   return std::make_pair( count, _pending_transactions.size() );
 }
 
 void mempool_impl::prune( std::chrono::seconds expiration, std::chrono::system_clock::time_point now )
@@ -466,9 +465,9 @@ uint64_t mempool::add_pending_transaction(
    return _my->add_pending_transaction( transaction, time, max_payer_rc, disk_storaged_used, network_bandwidth_used, compute_bandwidth_used );
 }
 
-void mempool::remove_pending_transactions( const std::vector< transaction_id_type >& ids )
+std::pair< uint64_t, uint64_t > mempool::remove_pending_transactions( const std::vector< transaction_id_type >& ids )
 {
-   _my->remove_pending_transactions( ids );
+   return _my->remove_pending_transactions( ids );
 }
 
 void mempool::prune( std::chrono::seconds expiration, std::chrono::system_clock::time_point now )

--- a/programs/koinos_mempool/main.cpp
+++ b/programs/koinos_mempool/main.cpp
@@ -289,21 +289,20 @@ int main( int argc, char** argv )
             {
                std::vector< mempool::transaction_id_type > ids;
                const auto& block = block_accept.block();
-               for ( int i = 0; i < block.transactions_size(); ++i )
-               {
-                  ids.emplace_back( block.transactions( i ).id() );
-               }
 
-               mempool->remove_pending_transactions( ids );
+               for ( int i = 0; i < block.transactions_size(); ++i )
+                  ids.emplace_back( block.transactions( i ).id() );
+
+               const auto [ removed, remaining ] = mempool->remove_pending_transactions( ids );
+
+               if ( removed || remaining )
+                  LOG(info) << "Removed " << removed << " included transaction(s) with " << remaining << " pending transaction(s) remaining"
+                     << " via block - Height: " << block.header().height() << ", ID: " << util::to_hex( block.id() );
             }
             catch ( const std::exception& e )
             {
-               LOG(info) << "Could not remove pending transaction: " << e.what();
+               LOG(warning) << "Could not remove pending transaction: " << e.what();
             }
-
-            auto num_pending_tx = mempool->pending_transaction_count();
-            if ( block_accept.live() && num_pending_tx )
-               LOG(info) << num_pending_tx << " pending transaction(s) exist in the pool";
          }
       );
 

--- a/programs/koinos_mempool/main.cpp
+++ b/programs/koinos_mempool/main.cpp
@@ -54,21 +54,21 @@ int main( int argc, char** argv )
    auto client = koinos::mq::client( client_ioc );
    auto timer = boost::asio::system_timer( server_ioc );
 
-   std::atomic< uint64_t > num_pruned = 0;
-   std::atomic< std::chrono::system_clock::time_point > last_prune_message = std::chrono::system_clock::now();
-
    timer_func_type timer_func = [&]( const boost::system::error_code& ec, std::shared_ptr< koinos::mempool::mempool > mpool, std::chrono::seconds exp_time )
    {
+      static uint64_t num_pruned = 0;
+      static auto last_message = std::chrono::system_clock::now();
+
       if ( ec == boost::asio::error::operation_aborted )
          return;
 
       num_pruned += mpool->prune( exp_time );
 
       auto now = std::chrono::system_clock::now();
-      if ( now - last_prune_message.load() >= std::chrono::minutes{ 1 } && num_pruned )
+      if ( now - last_message >= std::chrono::minutes{ 1 } && num_pruned )
       {
          LOG(info) << "Pruned " << num_pruned << " transaction(s) from mempool";
-         last_prune_message = now;
+         last_message = now;
          num_pruned = 0;
       }
 

--- a/programs/koinos_mempool/main.cpp
+++ b/programs/koinos_mempool/main.cpp
@@ -301,8 +301,9 @@ int main( int argc, char** argv )
                LOG(info) << "Could not remove pending transaction: " << e.what();
             }
 
-            if ( block_accept.live() )
-               LOG(info) << mempool->pending_transaction_count() << " pending transaction(s) exist in the pool";
+            auto num_pending_tx = mempool->pending_transaction_count();
+            if ( block_accept.live() && num_pending_tx )
+               LOG(info) << num_pending_tx << " pending transaction(s) exist in the pool";
          }
       );
 


### PR DESCRIPTION
## Brief description
When there are no pending transactions omit the log message.

## Checklist

- [x] I have built this pull request locally
- [x] I have ran the unit tests locally
- [x] I have manually tested this pull request
- [x] I have reviewed my pull request
- [x] I have added any relevant tests

