### PR TITLE
Add version/git info, add version option, bump version

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,8 @@
 cmake_minimum_required(VERSION 3.10.2)
 
+include("cmake/CheckGit.cmake")
+CheckGitSetup()
+
 find_program(CCACHE_PROGRAM ccache)
 if(CCACHE_PROGRAM)
    set_property(GLOBAL PROPERTY RULE_LAUNCH_COMPILE "${CCACHE_PROGRAM}")
@@ -35,7 +38,10 @@ HunterGate(
    LOCAL
 )
 
-project(koinos_mempool VERSION 0.1.0 LANGUAGES CXX C)
+project(koinos_mempool VERSION 1.0.0 LANGUAGES CXX C)
+add_compile_definitions(KOINOS_MAJOR_VERSION=${PROJECT_VERSION_MAJOR})
+add_compile_definitions(KOINOS_MINOR_VERSION=${PROJECT_VERSION_MINOR})
+add_compile_definitions(KOINOS_PATCH_VERSION=${PROJECT_VERSION_PATCH})
 
 option(FORCE_COLORED_OUTPUT "Always produce ANSI-colored output (GNU/Clang only)." OFF)
 

--- a/cmake/CheckGit.cmake
+++ b/cmake/CheckGit.cmake
@@ -59,7 +59,7 @@ endfunction()
 
 function(CheckGitSetup)
 
-    add_custom_target(AlwaysCheckGit COMMAND ${CMAKE_COMMAND}
+    add_custom_target(check_git COMMAND ${CMAKE_COMMAND}
         -DRUN_CHECK_GIT_VERSION=1
         -Dpre_configure_dir=${pre_configure_dir}
         -Dpost_configure_file=${post_configure_dir}
@@ -70,7 +70,7 @@ function(CheckGitSetup)
 
     add_library(git_version ${CMAKE_BINARY_DIR}/generated/git_version.cpp)
     target_include_directories(git_version PUBLIC ${CMAKE_BINARY_DIR}/generated)
-    add_dependencies(git_version AlwaysCheckGit)
+    add_dependencies(git_version check_git)
     add_library(Koinos::git ALIAS git_version)
 
     CheckGitVersion()

--- a/cmake/CheckGit.cmake
+++ b/cmake/CheckGit.cmake
@@ -1,0 +1,83 @@
+set(CURRENT_LIST_DIR ${CMAKE_CURRENT_LIST_DIR})
+if (NOT DEFINED pre_configure_dir)
+    set(pre_configure_dir ${CMAKE_CURRENT_LIST_DIR})
+endif ()
+
+if (NOT DEFINED post_configure_dir)
+    set(post_configure_dir ${CMAKE_BINARY_DIR}/generated)
+endif ()
+
+set(pre_configure_file ${pre_configure_dir}/git_version.cpp.in)
+set(post_configure_file ${post_configure_dir}/git_version.cpp)
+
+function(CheckGitWrite git_hash)
+    file(WRITE ${CMAKE_BINARY_DIR}/git-state.txt ${git_hash})
+endfunction()
+
+function(CheckGitRead git_hash)
+    if (EXISTS ${CMAKE_BINARY_DIR}/git-state.txt)
+        file(STRINGS ${CMAKE_BINARY_DIR}/git-state.txt CONTENT)
+        LIST(GET CONTENT 0 var)
+
+        set(${git_hash} ${var} PARENT_SCOPE)
+    endif ()
+endfunction()
+
+function(CheckGitVersion)
+    # Get the latest abbreviated commit hash of the working branch
+    execute_process(
+        COMMAND git log -1 --format=%h
+        WORKING_DIRECTORY ${CMAKE_CURRENT_LIST_DIR}
+        OUTPUT_VARIABLE GIT_HASH
+        OUTPUT_STRIP_TRAILING_WHITESPACE
+        )
+
+    CheckGitRead(GIT_HASH_CACHE)
+    if (NOT EXISTS ${post_configure_dir})
+        file(MAKE_DIRECTORY ${post_configure_dir})
+    endif ()
+
+    if (NOT EXISTS ${post_configure_dir}/git_version.h)
+        file(COPY ${pre_configure_dir}/git_version.h DESTINATION ${post_configure_dir})
+    endif()
+
+    if (NOT DEFINED GIT_HASH_CACHE)
+        set(GIT_HASH_CACHE "INVALID")
+    endif ()
+
+    # Only update the git_version.cpp if the hash has changed. This will
+    # prevent us from rebuilding the project more than we need to.
+    if (NOT ${GIT_HASH} STREQUAL ${GIT_HASH_CACHE} OR NOT EXISTS ${post_configure_file})
+        # Set che GIT_HASH_CACHE variable the next build won't have
+        # to regenerate the source file.
+        CheckGitWrite(${GIT_HASH})
+
+        configure_file(${pre_configure_file} ${post_configure_file} @ONLY)
+    endif ()
+
+endfunction()
+
+function(CheckGitSetup)
+
+    add_custom_target(AlwaysCheckGit COMMAND ${CMAKE_COMMAND}
+        -DRUN_CHECK_GIT_VERSION=1
+        -Dpre_configure_dir=${pre_configure_dir}
+        -Dpost_configure_file=${post_configure_dir}
+        -DGIT_HASH_CACHE=${GIT_HASH_CACHE}
+        -P ${CURRENT_LIST_DIR}/CheckGit.cmake
+        BYPRODUCTS ${post_configure_file}
+        )
+
+    add_library(git_version ${CMAKE_BINARY_DIR}/generated/git_version.cpp)
+    target_include_directories(git_version PUBLIC ${CMAKE_BINARY_DIR}/generated)
+    add_dependencies(git_version AlwaysCheckGit)
+    add_library(Koinos::git ALIAS git_version)
+
+    CheckGitVersion()
+endfunction()
+
+# This is used to run this function from an external cmake process.
+if (RUN_CHECK_GIT_VERSION)
+    CheckGitVersion()
+endif ()
+

--- a/cmake/git_version.cpp.in
+++ b/cmake/git_version.cpp.in
@@ -1,0 +1,3 @@
+#include "git_version.h"
+const char *KOINOS_GIT_HASH = "@GIT_HASH@";
+

--- a/cmake/git_version.h
+++ b/cmake/git_version.h
@@ -1,0 +1,3 @@
+#pragma once
+extern const char *KOINOS_GIT_HASH;
+

--- a/programs/koinos_mempool/CMakeLists.txt
+++ b/programs/koinos_mempool/CMakeLists.txt
@@ -3,7 +3,7 @@ file(GLOB HEADERS "include/*.hpp")
 add_executable(koinos_mempool
                main.cpp
                ${HEADERS})
-target_link_libraries(koinos_mempool PUBLIC Koinos::mempool Koinos::crypto Koinos::exception Koinos::proto Koinos::log Koinos::mq Boost::program_options yaml-cpp)
+target_link_libraries(koinos_mempool PUBLIC Koinos::mempool Koinos::crypto Koinos::exception Koinos::proto Koinos::log Koinos::mq Koinos::git Boost::program_options yaml-cpp)
 target_include_directories(koinos_mempool PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/include)
 install(TARGETS
    koinos_mempool


### PR DESCRIPTION
## Brief description
Adds version information and git hash. Adds `--version` and `-v` options. Bumps version.

## Checklist

- [x] I have built this pull request locally
- [x] I have ran the unit tests locally
- [x] I have manually tested this pull request
- [x] I have reviewed my pull request
- [x] I have added any relevant tests

## Demonstration
```console
❯ ./programs/koinos_mempool/Debug/koinos_mempool --version
Koinos Mempool v1.0.0 (ee20ce7)
❯ ./programs/koinos_mempool/Debug/koinos_mempool -v
Koinos Mempool v1.0.0 (ee20ce7)
❯ ./programs/koinos_mempool/Debug/koinos_mempool
2022-11-03 14:45:46.325125 (mempool.Koinos) [main.cpp:142] <info>: Koinos Mempool v1.0.0 (ee20ce7)
```
