### PR TITLE
Nonce limits

### DIFF
--- a/src/koinos/mempool/mempool.cpp
+++ b/src/koinos/mempool/mempool.cpp
@@ -115,9 +115,10 @@ std::string create_account_nonce_key( const protocol::transaction& transaction )
                                 transaction.header().payer().end() );
   }
 
+  auto nonce_bytes = util::converter::as< std::string >( util::converter::to< chain::value_type >( transaction.header().nonce() ).uint64_value() );
   account_nonce_bytes.insert( account_nonce_bytes.end(),
-                              transaction.header().nonce().begin(),
-                              transaction.header().nonce().end() );
+                              nonce_bytes.begin(),
+                              nonce_bytes.end() );
   return std::string( account_nonce_bytes.begin(), account_nonce_bytes.end() );
 }
 
@@ -379,10 +380,12 @@ bool mempool_impl::check_account_nonce( const account_type& payee,
 {
   auto lock = _db.get_shared_lock();
 
+  auto nonce_bytes = util::converter::as< std::string >( util::converter::to< chain::value_type >( nonce ).uint64_value() );
+
   std::vector< char > account_nonce_bytes;
   account_nonce_bytes.reserve( payee.size() + nonce.size() );
   account_nonce_bytes.insert( account_nonce_bytes.end(), payee.begin(), payee.end() );
-  account_nonce_bytes.insert( account_nonce_bytes.end(), nonce.begin(), nonce.end() );
+  account_nonce_bytes.insert( account_nonce_bytes.end(), nonce_bytes.begin(), nonce_bytes.end() );
   std::string account_nonce_key( account_nonce_bytes.begin(), account_nonce_bytes.end() );
 
   if( block_id.has_value() )
@@ -435,9 +438,7 @@ std::string mempool_impl::get_pending_nonce( const std::string& account,
 std::string mempool_impl::get_pending_nonce_on_node( state_db::abstract_state_node_ptr node,
                                                      const std::string& account ) const
 {
-  chain::value_type nonce;
-  nonce.set_uint64_value( std::numeric_limits< uint64_t >::max() );
-  auto nonce_bytes = util::converter::as< std::string >( nonce );
+  auto nonce_bytes = util::converter::as< std::string >( std::numeric_limits< uint64_t >::max() );
 
   std::vector< char > account_nonce_bytes;
   account_nonce_bytes.reserve( account.size() + nonce_bytes.size() );
@@ -457,7 +458,10 @@ std::string mempool_impl::get_pending_nonce_on_node( state_db::abstract_state_no
     return "";
 
   // Extract the nonce value from the returned key
-  return std::string( res.second, key.end() );
+  chain::value_type nonce;
+  nonce.set_uint64_value( util::converter::to< uint64_t >( std::string( res.second, key.end() ) ) );
+
+  return util::converter::as< std::string >( nonce );
 }
 
 uint64_t mempool_impl::add_pending_transaction_to_node( state_db::anonymous_state_node_ptr node,

--- a/src/koinos/mempool/mempool.cpp
+++ b/src/koinos/mempool/mempool.cpp
@@ -259,6 +259,11 @@ mempool_impl::get_pending_transactions( uint64_t limit, std::optional< crypto::m
 
   auto lock = _db.get_shared_lock();
 
+  // If the root is the head, we have not heard of blocks yet.
+  // The passed block ID may be legit, but in the past. Return the transactions we know about.
+  if( _db.get_head( lock )->id() == _db.get_root( lock )->id() )
+    block_id.reset();
+
   auto node = relevant_node( block_id, lock );
 
   KOINOS_ASSERT( node,

--- a/src/koinos/mempool/mempool.cpp
+++ b/src/koinos/mempool/mempool.cpp
@@ -115,10 +115,9 @@ std::string create_account_nonce_key( const protocol::transaction& transaction )
                                 transaction.header().payer().end() );
   }
 
-  auto nonce_bytes = util::converter::as< std::string >( util::converter::to< chain::value_type >( transaction.header().nonce() ).uint64_value() );
-  account_nonce_bytes.insert( account_nonce_bytes.end(),
-                              nonce_bytes.begin(),
-                              nonce_bytes.end() );
+  auto nonce_bytes = util::converter::as< std::string >(
+    util::converter::to< chain::value_type >( transaction.header().nonce() ).uint64_value() );
+  account_nonce_bytes.insert( account_nonce_bytes.end(), nonce_bytes.begin(), nonce_bytes.end() );
   return std::string( account_nonce_bytes.begin(), account_nonce_bytes.end() );
 }
 
@@ -380,7 +379,8 @@ bool mempool_impl::check_account_nonce( const account_type& payee,
 {
   auto lock = _db.get_shared_lock();
 
-  auto nonce_bytes = util::converter::as< std::string >( util::converter::to< chain::value_type >( nonce ).uint64_value() );
+  auto nonce_bytes =
+    util::converter::as< std::string >( util::converter::to< chain::value_type >( nonce ).uint64_value() );
 
   std::vector< char > account_nonce_bytes;
   account_nonce_bytes.reserve( payee.size() + nonce.size() );

--- a/src/koinos_mempool.cpp
+++ b/src/koinos_mempool.cpp
@@ -457,6 +457,8 @@ int main( int argc, char** argv )
                                                  {
                                                    return mempool->handle_block( block_accept );
                                                  } );
+
+                                               client.broadcast( "koinos.mempool.block_accepted", msg );
                                              }
                                              catch( const std::exception& e )
                                              {

--- a/tests/mempool_tests.cpp
+++ b/tests/mempool_tests.cpp
@@ -742,7 +742,7 @@ BOOST_AUTO_TEST_CASE( nonce_limits )
   uint64_t max_payer_resources = 1'000'000'000'000;
   chain::value_type nonce_value, expected_nonce;
 
-  nonce_value.set_uint64_value( 3071 );
+  nonce_value.set_uint64_value( 3'071 );
   trx.mutable_header()->set_rc_limit( 1 );
   trx.mutable_header()->set_payer( payer );
   trx.mutable_header()->set_nonce( util::converter::as< std::string >( nonce_value ) );
@@ -752,7 +752,7 @@ BOOST_AUTO_TEST_CASE( nonce_limits )
 
   BOOST_CHECK_EQUAL( mempool.get_pending_nonce( payer ), util::converter::as< std::string >( nonce_value ) );
 
-  nonce_value.set_uint64_value( 3072 );
+  nonce_value.set_uint64_value( 3'072 );
   trx.mutable_header()->set_nonce( util::converter::as< std::string >( nonce_value ) );
   trx.set_id( sign( _key1, trx ) );
 

--- a/tests/mempool_tests.cpp
+++ b/tests/mempool_tests.cpp
@@ -761,8 +761,4 @@ BOOST_AUTO_TEST_CASE( nonce_limits )
   BOOST_CHECK_EQUAL( mempool.get_pending_nonce( payer ), util::converter::as< std::string >( nonce_value ) );
 }
 
-// 2815
-// 2943
-// 3071
-
 BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
## Brief description

Fixes a problem with Protobuf's little endian encoding that caused an address to no longer be able to add more pending transactions to the mempool until those transactions were included.

Broadcasts blocks from mempool for block producer to listen to.

Handled genesis production case.

## Checklist

- [X] I have built this pull request locally
- [X] I have ran the unit tests locally
- [X] I have manually tested this pull request
- [X] I have reviewed my pull request
- [X] I have added any relevant tests

## Demonstration
<!-- If applicable, attach screenshot or terminal output of working code -->
