### PR TITLE
#263: Implement get_pending_transaction_count

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,7 +6,7 @@ include(FetchContent)
 FetchContent_Declare(
   koinos_cmake
   GIT_REPOSITORY https://github.com/koinos/koinos-cmake.git
-  GIT_TAG        v1.0.4)
+  GIT_TAG        v1.0.6)
 FetchContent_MakeAvailable(koinos_cmake)
 
 include("${koinos_cmake_SOURCE_DIR}/Koinos.cmake")

--- a/src/koinos/mempool/mempool.cpp
+++ b/src/koinos/mempool/mempool.cpp
@@ -52,7 +52,8 @@ private:
 
   std::string get_pending_nonce_on_node( state_db::abstract_state_node_ptr node, const std::string& account ) const;
 
-  uint64_t get_pending_transaction_count_on_node( state_db::abstract_state_node_ptr node, const std::string& account ) const;
+  uint64_t get_pending_transaction_count_on_node( state_db::abstract_state_node_ptr node,
+                                                  const std::string& account ) const;
 
   uint64_t add_pending_transaction_to_node( state_db::anonymous_state_node_ptr node,
                                             const protocol::transaction& transaction,
@@ -87,7 +88,8 @@ public:
 
   std::string get_pending_nonce( const std::string& account, std::optional< crypto::multihash > block_id ) const;
 
-  uint64_t get_pending_transaction_count( const std::string& account, std::optional< crypto::multihash > block_id ) const;
+  uint64_t get_pending_transaction_count( const std::string& account,
+                                          std::optional< crypto::multihash > block_id ) const;
 
   uint64_t add_pending_transaction( const protocol::transaction& transaction,
                                     std::chrono::system_clock::time_point time,
@@ -512,7 +514,7 @@ std::string mempool_impl::get_pending_nonce_on_node( state_db::abstract_state_no
 }
 
 uint64_t mempool_impl::get_pending_transaction_count( const std::string& account,
-                                                         std::optional< crypto::multihash > block_id ) const
+                                                      std::optional< crypto::multihash > block_id ) const
 {
   auto lock = _db.get_shared_lock();
   state_db::state_node_ptr node;
@@ -889,7 +891,8 @@ std::string mempool::get_pending_nonce( const std::string& account, std::optiona
   return _my->get_pending_nonce( account, block_id );
 }
 
-uint64_t mempool::get_pending_transaction_count( const std::string& account, std::optional< crypto::multihash > block_id ) const
+uint64_t mempool::get_pending_transaction_count( const std::string& account,
+                                                 std::optional< crypto::multihash > block_id ) const
 {
   return _my->get_pending_transaction_count( account, block_id );
 }

--- a/src/koinos/mempool/mempool.cpp
+++ b/src/koinos/mempool/mempool.cpp
@@ -52,6 +52,8 @@ private:
 
   std::string get_pending_nonce_on_node( state_db::abstract_state_node_ptr node, const std::string& account ) const;
 
+  uint64_t get_pending_transaction_count_on_node( state_db::abstract_state_node_ptr node, const std::string& account ) const;
+
   uint64_t add_pending_transaction_to_node( state_db::anonymous_state_node_ptr node,
                                             const protocol::transaction& transaction,
                                             std::chrono::system_clock::time_point time,
@@ -84,6 +86,8 @@ public:
                             std::optional< crypto::multihash > block_id = {} ) const;
 
   std::string get_pending_nonce( const std::string& account, std::optional< crypto::multihash > block_id ) const;
+
+  uint64_t get_pending_transaction_count( const std::string& account, std::optional< crypto::multihash > block_id ) const;
 
   uint64_t add_pending_transaction( const protocol::transaction& transaction,
                                     std::chrono::system_clock::time_point time,
@@ -507,6 +511,63 @@ std::string mempool_impl::get_pending_nonce_on_node( state_db::abstract_state_no
   return util::converter::as< std::string >( nonce );
 }
 
+uint64_t mempool_impl::get_pending_transaction_count( const std::string& account,
+                                                         std::optional< crypto::multihash > block_id ) const
+{
+  auto lock = _db.get_shared_lock();
+  state_db::state_node_ptr node;
+  std::shared_ptr< std::shared_mutex > mutex;
+
+  if( block_id.has_value() )
+    std::tie( node, mutex ) = relevant_node( block_id, lock );
+  else
+    std::tie( node, mutex ) = relevant_node( _db.get_head( lock )->id(), lock );
+
+  KOINOS_ASSERT( node, pending_transaction_unknown_block, "cannot check pending nonce from an unknown block" );
+
+  std::shared_lock< std::shared_mutex > node_lock( *mutex );
+  return get_pending_transaction_count_on_node( node, account );
+}
+
+uint64_t mempool_impl::get_pending_transaction_count_on_node( state_db::abstract_state_node_ptr node,
+                                                              const std::string& account ) const
+{
+  auto nonce_bytes = util::converter::as< std::string >( std::numeric_limits< uint64_t >::max() );
+
+  std::vector< char > account_nonce_bytes;
+  account_nonce_bytes.reserve( account.size() + nonce_bytes.size() );
+  account_nonce_bytes.insert( account_nonce_bytes.end(), account.begin(), account.end() );
+  account_nonce_bytes.insert( account_nonce_bytes.end(), nonce_bytes.begin(), nonce_bytes.end() );
+  std::string account_nonce_key( account_nonce_bytes.begin(), account_nonce_bytes.end() );
+
+  uint64_t count = 0;
+
+  // Perform a linear walk to count pending transactions for an account.
+  // This is an O(n) algorithm for the number of transactions per account.
+  // We are going to start with a small limit, so this value will be double digits.
+  // As an optimization, we should add another table to track the count separately.
+  // But that will be done later due to the added complexity and potential
+  // introduction of errors.
+  while( true )
+  {
+    const auto [ value, key ] = node->get_prev_object( space::account_nonce(), account_nonce_key );
+
+    if( !value )
+      break;
+
+    auto res = std::mismatch( account.begin(), account.end(), key.begin() );
+
+    // If the account is not a prefix of the key, then our account has no pending nonce
+    if( res.first != account.end() )
+      break;
+
+    account_nonce_key = key;
+    count++;
+  }
+
+  return count;
+}
+
 uint64_t mempool_impl::add_pending_transaction_to_node( state_db::anonymous_state_node_ptr node,
                                                         const protocol::transaction& transaction,
                                                         std::chrono::system_clock::time_point time,
@@ -826,6 +887,11 @@ bool mempool::check_account_nonce( const account_type& payee,
 std::string mempool::get_pending_nonce( const std::string& account, std::optional< crypto::multihash > block_id ) const
 {
   return _my->get_pending_nonce( account, block_id );
+}
+
+uint64_t mempool::get_pending_transaction_count( const std::string& account, std::optional< crypto::multihash > block_id ) const
+{
+  return _my->get_pending_transaction_count( account, block_id );
 }
 
 uint64_t mempool::add_pending_transaction( const protocol::transaction& transaction,

--- a/src/koinos/mempool/mempool.hpp
+++ b/src/koinos/mempool/mempool.hpp
@@ -55,6 +55,8 @@ public:
 
   std::string get_pending_nonce( const std::string& account, std::optional< crypto::multihash > block_id = {} ) const;
 
+  uint64_t get_pending_transaction_count( const std::string& account, std::optional< crypto::multihash > block_id = {} ) const;
+
   uint64_t add_pending_transaction( const protocol::transaction& transaction,
                                     std::chrono::system_clock::time_point time,
                                     uint64_t max_payer_rc,

--- a/src/koinos/mempool/mempool.hpp
+++ b/src/koinos/mempool/mempool.hpp
@@ -55,7 +55,8 @@ public:
 
   std::string get_pending_nonce( const std::string& account, std::optional< crypto::multihash > block_id = {} ) const;
 
-  uint64_t get_pending_transaction_count( const std::string& account, std::optional< crypto::multihash > block_id = {} ) const;
+  uint64_t get_pending_transaction_count( const std::string& account,
+                                          std::optional< crypto::multihash > block_id = {} ) const;
 
   uint64_t add_pending_transaction( const protocol::transaction& transaction,
                                     std::chrono::system_clock::time_point time,

--- a/src/koinos_mempool.cpp
+++ b/src/koinos_mempool.cpp
@@ -346,6 +346,15 @@ int main( int argc, char** argv )
                                      : std::optional< crypto::multihash >{} ) );
                   break;
                 }
+              case rpc::mempool::mempool_request::RequestCase::kGetPendingTransactionCount:
+                {
+                  const auto& p = args.get_pending_transaction_count();
+                  resp.mutable_get_pending_transaction_count()->set_count( mempool->get_pending_transaction_count(
+                    p.payee(),
+                    p.has_block_id() ? util::converter::to< crypto::multihash >( p.block_id() )
+                                     : std::optional< crypto::multihash >{} ) );
+                  break;
+                }
               case rpc::mempool::mempool_request::RequestCase::kReserved:
                 resp.mutable_reserved();
                 break;

--- a/tests/mempool_tests.cpp
+++ b/tests/mempool_tests.cpp
@@ -691,6 +691,7 @@ BOOST_AUTO_TEST_CASE( pending_nonce_test )
   trx.mutable_header()->set_payer( payer );
   trx.mutable_header()->set_nonce( util::converter::as< std::string >( nonce_value ) );
   trx.set_id( sign( _key1, trx ) );
+  auto trx_1_id = trx.id();
 
   mempool.add_pending_transaction( trx, std::chrono::system_clock::now(), max_payer_resources, 1, 1, 1 );
 
@@ -726,12 +727,24 @@ BOOST_AUTO_TEST_CASE( pending_nonce_test )
   nonce_value.set_uint64_value( 2 );
   trx.mutable_header()->set_nonce( util::converter::as< std::string >( nonce_value ) );
   trx.set_id( sign( _key1, trx ) );
+  auto trx_2_id = trx.id();
 
   mempool.add_pending_transaction( trx, std::chrono::system_clock::now(), max_payer_resources, 1, 1, 1 );
 
   BOOST_CHECK_EQUAL( mempool.get_pending_nonce( payer ), util::converter::as< std::string >( nonce_value ) );
   BOOST_CHECK_EQUAL( mempool.get_pending_nonce( payer, crypto::multihash::zero( crypto::multicodec::sha2_256 ) ),
                      util::converter::as< std::string >( nonce_value ) );
+
+  BOOST_CHECK_EQUAL( mempool.get_pending_transaction_count( payer ), 1 );
+  BOOST_CHECK_EQUAL( mempool.get_pending_transaction_count( payer2 ), 0 );
+  BOOST_CHECK_EQUAL( mempool.get_pending_transaction_count( payer3 ), 0 );
+
+  BOOST_CHECK_EQUAL( mempool.get_pending_transaction_count( payer, crypto::multihash::zero( crypto::multicodec::sha2_256 ) ), 2 );
+  BOOST_CHECK_EQUAL( mempool.get_pending_transaction_count( payer2, crypto::multihash::zero( crypto::multicodec::sha2_256 ) ), 0 );
+  BOOST_CHECK_EQUAL( mempool.get_pending_transaction_count( payer3, crypto::multihash::zero( crypto::multicodec::sha2_256 ) ), 0 );
+
+  mempool.remove_pending_transactions( {trx_2_id } );
+  BOOST_CHECK_EQUAL( mempool.get_pending_transaction_count( payer ), 0 );
 }
 
 BOOST_AUTO_TEST_CASE( nonce_limits )

--- a/tests/mempool_tests.cpp
+++ b/tests/mempool_tests.cpp
@@ -739,11 +739,17 @@ BOOST_AUTO_TEST_CASE( pending_nonce_test )
   BOOST_CHECK_EQUAL( mempool.get_pending_transaction_count( payer2 ), 0 );
   BOOST_CHECK_EQUAL( mempool.get_pending_transaction_count( payer3 ), 0 );
 
-  BOOST_CHECK_EQUAL( mempool.get_pending_transaction_count( payer, crypto::multihash::zero( crypto::multicodec::sha2_256 ) ), 2 );
-  BOOST_CHECK_EQUAL( mempool.get_pending_transaction_count( payer2, crypto::multihash::zero( crypto::multicodec::sha2_256 ) ), 0 );
-  BOOST_CHECK_EQUAL( mempool.get_pending_transaction_count( payer3, crypto::multihash::zero( crypto::multicodec::sha2_256 ) ), 0 );
+  BOOST_CHECK_EQUAL(
+    mempool.get_pending_transaction_count( payer, crypto::multihash::zero( crypto::multicodec::sha2_256 ) ),
+    2 );
+  BOOST_CHECK_EQUAL(
+    mempool.get_pending_transaction_count( payer2, crypto::multihash::zero( crypto::multicodec::sha2_256 ) ),
+    0 );
+  BOOST_CHECK_EQUAL(
+    mempool.get_pending_transaction_count( payer3, crypto::multihash::zero( crypto::multicodec::sha2_256 ) ),
+    0 );
 
-  mempool.remove_pending_transactions( {trx_2_id } );
+  mempool.remove_pending_transactions( { trx_2_id } );
   BOOST_CHECK_EQUAL( mempool.get_pending_transaction_count( payer ), 0 );
 }
 


### PR DESCRIPTION
Resolves #263

## Brief description
Adds the `get_pending_transaction_count` RPC

## Checklist

- [X] I have built this pull request locally
- [X] I have ran the unit tests locally
- [X] I have manually tested this pull request
- [X] I have reviewed my pull request
- [X] I have added any relevant tests

## Demonstration
<!-- If applicable, attach screenshot or terminal output of working code -->
